### PR TITLE
fix: compatible with Obsidian 1.2.0 version

### DIFF
--- a/src/click-handler.ts
+++ b/src/click-handler.ts
@@ -14,8 +14,8 @@ export const getClickHandler = (plugin: ALxFolderNote) => {
       evt.shiftKey ||
       // triggered only when click on title
       !(
-        (getFileItemInnerTitleEl(item) === evt.target ||
-        getFileItemInnerTitleEl(item).contains(evt.target as Node))
+        getFileItemInnerTitleEl(item) === evt.target ||
+        getFileItemInnerTitleEl(item).contains(evt.target as Node)
       ) ||
       // ignore file being renamed
       item.fileExplorer.fileBeingRenamed === item.file

--- a/src/click-handler.ts
+++ b/src/click-handler.ts
@@ -1,7 +1,7 @@
 import { FolderItem, Platform } from "obsidian";
 
 import type ALxFolderNote from "./fn-main";
-import { isModifier } from "./misc";
+import { isModifier, getFileItemInnerTitleEl } from "./misc";
 import { LongPressEvent } from "./modules/long-press";
 
 export const getClickHandler = (plugin: ALxFolderNote) => {
@@ -14,8 +14,8 @@ export const getClickHandler = (plugin: ALxFolderNote) => {
       evt.shiftKey ||
       // triggered only when click on title
       !(
-        item.titleInnerEl === evt.target ||
-        item.titleInnerEl.contains(evt.target as Node)
+        (getFileItemInnerTitleEl(item) === evt.target ||
+        getFileItemInnerTitleEl(item).contains(evt.target as Node))
       ) ||
       // ignore file being renamed
       item.fileExplorer.fileBeingRenamed === item.file

--- a/src/fe-handler/active-folder.ts
+++ b/src/fe-handler/active-folder.ts
@@ -7,6 +7,7 @@ import {
 
 import type ALxFolderNote from "../fn-main";
 import FEHandler_Base from "./base";
+import { getFileItemTitleEl } from '../misc';
 
 const isActiveClass = "is-active";
 
@@ -27,7 +28,7 @@ export default class ActiveFolder extends FEHandler_Base {
   private _activeFolder: TFolder | null = null;
   public set activeFolder(folder: TFolder | null) {
     const getTitleEl = (folder: TFolder | null) =>
-      folder ? this.fileExplorer.fileItems[folder.path]?.titleEl : undefined;
+      folder && this.fileExplorer.fileItems[folder.path] ? getFileItemTitleEl(this.fileExplorer.fileItems[folder.path]) : undefined;
     if (!folder) {
       getTitleEl(this._activeFolder)?.removeClass(isActiveClass);
     } else if (folder !== this._activeFolder) {

--- a/src/fe-patch.ts
+++ b/src/fe-patch.ts
@@ -131,6 +131,12 @@ const PatchFileExplorer = (plugin: ALxFolderNote) => {
           // fallback to default
           if (!(await clickHandler(this, evt))) next.call(this, evt);
         },
+      onSelfClick: (next) =>
+        async function (this: FolderItemCls, evt) {
+          // if folder note click not success,
+          // fallback to default
+          if (!(await clickHandler(this, evt))) next.call(this, evt);
+        },
     }),
   ];
   resetFileExplorer(plugin);

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -9,7 +9,7 @@ import {
   View,
   WorkspaceLeaf,
 } from "obsidian";
-import { Notice, Platform, TFolder } from "obsidian";
+import { Notice, Platform, TFolder, FileItem } from "obsidian";
 import { dirname, extname, join } from "path";
 
 export type afItemMark = AFItem & {
@@ -83,4 +83,12 @@ export class ClickNotice extends Notice {
       this.noticeEl.append(frag);
     }
   }
+}
+
+export function getFileItemTitleEl(fileItem: FileItem): HTMLElement {
+  return fileItem.titleEl ?? fileItem.selfEl;
+}
+
+export function getFileItemInnerTitleEl(fileItem: FileItem): HTMLElement {
+  return fileItem.titleInnerEl ?? fileItem.innerEl;
 }

--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -83,7 +83,11 @@ declare module "obsidian" {
     collapsed: boolean;
     pusherEl: HTMLDivElement;
     setCollapsed(collapsed: boolean): Promise<void>;
-    onTitleElClick(evt: MouseEvent): any;
+    /**
+     * @deprecated After Obsidian 1.2.0, use `onSelfClick` instead.
+     */
+    onTitleElClick?(evt: MouseEvent): any;
+    onSelfClick(evt: MouseEvent): any;
   }
 
   interface Vault {

--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -50,16 +50,32 @@ declare module "obsidian" {
     file: TFile;
     fileExplorer: FileExplorerView;
     info: any;
-    titleEl: HTMLDivElement;
-    titleInnerEl: HTMLDivElement;
+    /**
+     * @deprecated After Obsidian 1.2.0, use `selfEl` instead.
+     */
+    titleEl?: HTMLDivElement;
+    /**
+     * @deprecated After Obsidian 1.2.0, use `innerEl` instead.
+     */
+    titleInnerEl?: HTMLDivElement;
+    selfEl: HTMLDivElement;
+    innerEl: HTMLDivElement;
   }
 
   class FolderItem {
     el: HTMLDivElement;
     fileExplorer: FileExplorerView;
     info: any;
-    titleEl: HTMLDivElement;
-    titleInnerEl: HTMLDivElement;
+    /**
+     * @deprecated After Obsidian 1.2.0, use `selfEl` instead.
+     */
+    titleEl?: HTMLDivElement;
+    /**
+     * @deprecated After Obsidian 1.2.0, use `innerEl` instead.
+     */
+    titleInnerEl?: HTMLDivElement;
+    selfEl: HTMLDivElement;
+    innerEl: HTMLDivElement;
     file: TFolder;
     children: AFItem[];
     childrenEl: HTMLDivElement;


### PR DESCRIPTION
this close: #102 

related: 
- https://github.com/FlorianWoelki/obsidian-icon-folder/pull/165


---

@aidenlx currently I cannot run this repo success. it seem you have some private package inside package.json
such as:
- @aidenlx/ts-config
- @aidenlx/prettier-config

and the dep is broken:
<img width="1483" alt="CleanShot 2023-03-31 at 14 04 03@2x" src="https://user-images.githubusercontent.com/13938334/229036524-b72eb618-eba1-4dca-a7c2-40d5e65802d3.png">

I delete the `yarn.lock` and it resolved, so I don't know if I should submit yarn.lock.
