### PR TITLE
fix: check whether FileExplorerView.dom is defined before use

### DIFF
--- a/src/fe-handler/folder-focus.ts
+++ b/src/fe-handler/folder-focus.ts
@@ -59,7 +59,7 @@ export default class FolderFocus extends FEHandler_Base {
         this.fileExplorer.dom.infinityScroll.scrollIntoView(item);
       });
     }
-    this.fileExplorer.dom.navFileContainerEl.toggleClass(focusModeCls, !!item);
+    this.fileExplorer.dom?.navFileContainerEl?.toggleClass(focusModeCls, !!item);
   }
   toggleFocusFolder(folder: TFolder | null) {
     const folderItem = folder

--- a/src/fe-patch.ts
+++ b/src/fe-patch.ts
@@ -65,7 +65,7 @@ const PatchFileExplorer = (plugin: ALxFolderNote) => {
           const self = this;
           next.call(self);
           self.folderNoteUtils = getFileExplorerHandlers(plugin, self);
-          AddLongPressEvt(plugin, self.dom.navFileContainerEl);
+          if (typeof self.dom?.navFileContainerEl !== "undefined") AddLongPressEvt(plugin, self.dom.navFileContainerEl);
           self.containerEl.on(
             "auxclick",
             ".nav-folder",


### PR DESCRIPTION
Fixes #130

This is a quick fix, checking whether `dom` is defined before using or passing it around, but it doesn't deal with any potentially broken assumptions.