### PR TITLE
fix: issue #134, dom reference error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ build
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+#System Files
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   // Disable vscode formatting for js,jsx,ts,tsx files
   // to allow dbaeumer.vscode-eslint to format them

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,4 +1,4 @@
-import obPlugin from "@aidenlx/esbuild-plugin-obsidian";
+import obPlugin from "./scripts/obPlugin.mjs";
 import { build, context } from "esbuild";
 import { lessLoader } from "esbuild-plugin-less";
 

--- a/log.md
+++ b/log.md
@@ -1,0 +1,12 @@
+Removed following packages no longer available from developer on Github
+"@aidenlx/esbuild-plugin-obsidian": "^0.1.8",
+"@aidenlx/obsidian-plugin-bumper": "^0.1.12",
+
+obPlugin module was recovered from https://www.npmjs.com/package/@aidenlx/esbuild-plugin-obsidian
+
+Changes marked as following
+//Note: Bug fix introduced in v1.5.4
+
+Adjusted manifest name to "AidenLx's Folder Note Reworked" for testing along side active plugin
+
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "id": "alx-folder-note-rework",
-  "name": "AidenLx's Folder Note Reworked",
+  "id": "alx-folder-note",
+  "name": "AidenLx's Folder Note",
   "version": "0.17.0",
   "minAppVersion": "1.1.0",
   "description": "Add description, summary and more info to folders with folder notes.",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "id": "alx-folder-note",
-  "name": "AidenLx's Folder Note",
-  "version": "0.16.5",
+  "id": "alx-folder-note-rework",
+  "name": "AidenLx's Folder Note Reworked",
+  "version": "0.17.0",
   "minAppVersion": "1.1.0",
   "description": "Add description, summary and more info to folders with folder notes.",
   "author": "AidenLx",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@aidenlx/esbuild-plugin-obsidian": "^0.1.8",
     "@aidenlx/folder-note-core": "^1.3.3",
     "@aidenlx/obsidian-icon-shortcodes": "^0.9.0",
-    "@aidenlx/obsidian-plugin-bumper": "^0.1.12",
     "@release-it/bumper": "^4.0.0",
     "@release-it/conventional-changelog": "^5.1.0",
     "@types/array.prototype.flat": "^1.2.1",

--- a/scripts/obPlugin.mjs
+++ b/scripts/obPlugin.mjs
@@ -1,0 +1,48 @@
+import { promises } from "fs";
+import { dirname, join } from "path";
+
+const { copyFile, rename, writeFile } = promises;
+
+/**
+ * @param {{ hotreload?: boolean, beta?:boolean }} config
+ * @returns {import("esbuild").Plugin}
+ */
+const obPlugin = (config = {}) => ({
+  name: "obsidian-plugin",
+  setup: (build) => {
+    const { hotreload = true, beta = false } = config;
+    build.onEnd(async () => {
+      const outDir = dirname(build.initialOptions.outfile ?? "main.js");
+      // fix default css output file name
+      const { outfile } = build.initialOptions;
+      try {
+        await rename(
+          outfile.replace(/\.js$/, ".css"),
+          outfile.replace(/main\.js$/, "styles.css"),
+        );
+      } catch (err) {
+        if (err.code !== "ENOENT") throw err;
+      }
+
+      // copy manifest.json to build dir
+      if (!beta) {
+        await copyFile("manifest.json", join(outDir, "manifest.json"));
+      } else {
+        await copyFile("manifest-beta.json", join(outDir, "manifest.json"));
+      }
+
+      // create .hotreload if it doesn't exist
+      if (hotreload) {
+        try {
+          await writeFile(join(outDir, ".hotreload"), "", { flag: "wx" });
+        } catch (err) {
+          if (err.code !== "EEXIST") throw err;
+        }
+      }
+
+      console.log("build finished");
+    });
+  },
+});
+
+export default obPlugin;

--- a/src/click-handler.ts
+++ b/src/click-handler.ts
@@ -19,7 +19,9 @@ export const getClickHandler = (plugin: ALxFolderNote) => {
         getFileItemInnerTitleEl(item).contains(evt.target as Node)
       ) ||
       // ignore file being renamed
-      item.fileExplorer.fileBeingRenamed === item.file
+
+      //Note: Bug fix introduced in v1.5.4
+      item.fileExplorer?.fileBeingRenamed === item.file
     )
       return false;
 

--- a/src/fe-handler/file-explorer.less
+++ b/src/fe-handler/file-explorer.less
@@ -1,5 +1,9 @@
-body:not(.alx-no-hide-note) .nav-file.alx-folder-note > .nav-file-title {
-  display: none;
+body:not(.alx-no-hide-note) {
+  .nav-file.alx-folder-note {
+    > .nav-file-title {
+      display: none;
+    }
+  }
 }
 
 .nav-folder.alx-folder-with-note {

--- a/src/fe-handler/folder-focus.ts
+++ b/src/fe-handler/folder-focus.ts
@@ -49,18 +49,21 @@ export default class FolderFocus extends FEHandler_Base {
       ? { folder: item, collapsedCache: item.collapsed }
       : null;
     // unfold folder if it's collapsed
+
+    //Note: Bug fix introduced in v1.5.4
     if (item && item.collapsed) {
       item.setCollapsed(false);
       // @ts-ignore
       this.plugin.app.nextFrame(() => {
         // @ts-ignore
-        this.fileExplorer.dom.infinityScroll.computeSync();
+        this.fileExplorer.tree.infinityScroll.computeSync();
         // @ts-ignore
-        this.fileExplorer.dom.infinityScroll.scrollIntoView(item);
+        this.fileExplorer.tree.infinityScroll.scrollIntoView(item);
       });
     }
-    this.fileExplorer.dom.navFileContainerEl.toggleClass(focusModeCls, !!item);
+    this.fileExplorer.navFileContainerEl.toggleClass(focusModeCls, !!item);
   }
+  
   toggleFocusFolder(folder: TFolder | null) {
     const folderItem = folder
       ? (this.getAfItem(folder.path) as FolderItem | null)

--- a/src/fe-patch.ts
+++ b/src/fe-patch.ts
@@ -65,7 +65,11 @@ const PatchFileExplorer = (plugin: ALxFolderNote) => {
           const self = this;
           next.call(self);
           self.folderNoteUtils = getFileExplorerHandlers(plugin, self);
-          AddLongPressEvt(plugin, self.dom.navFileContainerEl);
+
+          // Note: Bug fix introduced in v1.5.4
+          // self.dom.navFileContainerEl
+          AddLongPressEvt(plugin, self.navFileContainerEl);
+
           self.containerEl.on(
             "auxclick",
             ".nav-folder",


### PR DESCRIPTION
Fix in response to #134.
Folder notes no longer open when clicking on the folder (Obsidian Desktop v1.5.4).

The project was not building, failing on two **@aidenlx/** packages. 
Removed both and manually added the obPlugin module to scripts to restore build functionality.
Additional notes added to _log.md_ file